### PR TITLE
feat: use cryptographically strong random number generation method

### DIFF
--- a/EcdsaDotNet/EcdsaDotNet/utils/integer.cs
+++ b/EcdsaDotNet/EcdsaDotNet/utils/integer.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Numerics;
-
+using System.Security.Cryptography;
 
 namespace EllipticCurve.Utils {
 
     public static class Integer {
-
-        static Random random = new Random();
-
         public static BigInteger modulo(BigInteger dividend, BigInteger divisor) {
             BigInteger remainder = BigInteger.Remainder(dividend, divisor);
             
@@ -30,7 +27,10 @@ namespace EllipticCurve.Utils {
             BigInteger mask = response.Item2;
 
             byte[] randomBytes = new byte[bytesNeeded];
-            random.NextBytes(randomBytes);
+            using (var random = RandomNumberGenerator.Create())
+            {
+                random.GetBytes(randomBytes);
+            }
 
             BigInteger randomValue = new BigInteger(randomBytes);
 


### PR DESCRIPTION
Currently in order to verify signature we are using weak photographically random number generator `Random`. It is troublesome for projects that are using static software analysis and this is caught in the library scan. For example Veracode mark usage of `Random` as this library vulnerability.

In order to mitigate that it is better to use [RandomNumberGenerator.GetBytes Method](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator.getbytes?view=net-5.0#System_Security_Cryptography_RandomNumberGenerator_GetBytes_System_Byte___). If we read method description:

> Fills an array of bytes with a cryptographically strong random sequence of values.

We can clearly see that this approach is going to be superior to the former approach.