### PR TITLE
feat(ecdsa): add byte[] overloads for message input

### DIFF
--- a/EcdsaDotNet/EcdsaDotNet/ecdsa.cs
+++ b/EcdsaDotNet/EcdsaDotNet/ecdsa.cs
@@ -18,6 +18,19 @@ namespace EllipticCurve {
             return new Signature(r, s);
         }
 
+        public static Signature sign(byte[] bytes, PrivateKey privateKey)
+        {
+            string hashMessage = sha256(bytes);
+            BigInteger numberMessage = Utils.BinaryAscii.numberFromHex(hashMessage);
+            CurveFp curve = privateKey.curve;
+            BigInteger randNum = Utils.Integer.randomBetween(BigInteger.One, curve.N - 1);
+            Point randSignPoint = EcdsaMath.multiply(curve.G, randNum, curve.N, curve.A, curve.P);
+            BigInteger r = Utils.Integer.modulo(randSignPoint.x, curve.N);
+            BigInteger s = Utils.Integer.modulo((numberMessage + r * privateKey.secret) * (EcdsaMath.inv(randNum, curve.N)), curve.N);
+
+            return new Signature(r, s);
+        }
+
         public static bool verify(string message, Signature signature, PublicKey publicKey) {
             string hashMessage = sha256(message);
             BigInteger numberMessage = Utils.BinaryAscii.numberFromHex(hashMessage);
@@ -60,6 +73,52 @@ namespace EllipticCurve {
             return Utils.Integer.modulo(v.x, curve.N) == sigR;
         }
 
+        public static bool verify(byte[] message, Signature signature, PublicKey publicKey)
+        {
+            string hashMessage = sha256(message);
+            BigInteger numberMessage = Utils.BinaryAscii.numberFromHex(hashMessage);
+            CurveFp curve = publicKey.curve;
+            BigInteger sigR = signature.r;
+            BigInteger sigS = signature.s;
+
+            if (sigR < 1 || sigR >= curve.N)
+            {
+                return false;
+            }
+            if (sigS < 1 || sigS >= curve.N)
+            {
+                return false;
+            }
+
+            BigInteger inv = EcdsaMath.inv(sigS, curve.N);
+
+            Point u1 = EcdsaMath.multiply(
+                curve.G,
+                Utils.Integer.modulo((numberMessage * inv), curve.N),
+                curve.N,
+                curve.A,
+                curve.P
+            );
+            Point u2 = EcdsaMath.multiply(
+                publicKey.point,
+                Utils.Integer.modulo((sigR * inv), curve.N),
+                curve.N,
+                curve.A,
+                curve.P
+            );
+            Point v = EcdsaMath.add(
+                u1,
+                u2,
+                curve.A,
+                curve.P
+            );
+            if (v.isAtInfinity())
+            {
+                return false;
+            }
+            return Utils.Integer.modulo(v.x, curve.N) == sigR;
+        }
+
         private static string sha256(string message) {
             byte[] bytes;
 
@@ -69,6 +128,24 @@ namespace EllipticCurve {
 
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i < bytes.Length; i++) {
+                builder.Append(bytes[i].ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string sha256(byte[] messageBytes)
+        {
+            byte[] bytes;
+
+            using (SHA256 sha256Hash = SHA256.Create())
+            {
+                bytes = sha256Hash.ComputeHash(messageBytes);
+            }
+
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < bytes.Length; i++)
+            {
                 builder.Append(bytes[i].ToString("x2"));
             }
 


### PR DESCRIPTION
This PR adds new overloads in the ECDSA class that accept `byte[]` messages.

Motivation:  
While implementing a virtual FIDO2 security key, I needed to sign a byte array to respond to an Assertion request.  
Converting the byte array to a hex string did not help, as the resulting hash differs from hashing the original byte array directly.  
These overloads allow signing and verifying binary messages without unnecessary conversions.

Changes:
- Added `Verify`, `Sign`, and `Sha256` overloads with a `byte[]` message parameter.

No breaking changes.
